### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 Contact: [braindamageinc@gmail.com](mailto:braindamageinc@gmail.com)
 
-##Summary
+## Summary
 Makes HTTP requests using the selected text as URL + headers. Useful for testing REST APIs from Sublime Text 2 editor. 
 
-##Update: Added latency and download time output.
+## Update: Added latency and download time output.
 
-##Usage
+## Usage
 Select the text that represents an URL. Examples of requests:
 
 	http://www.google.com/search?q=test
@@ -26,7 +26,7 @@ If you need to add extra headers just add them below the URL line, one on each l
 Use the right-click context menu command *Http Requester* or the keyboard shortcut *CTRL + ALT + R*  ( *COMMAND + ALT + R* on Mac OS X ).
 Update: *F5* refreshes last request.
 
-###POST/PUT usage
+### POST/PUT usage
 Just add **POST_BODY:** after any extra headers and the body on the following lines:
 
 	POST http://posttestserver.com/post.php
@@ -47,12 +47,12 @@ For PUT:
 	POST_BODY:
 	this body will be sent via HTTP PUT
 
-###DELETE usage
+### DELETE usage
 Same as HTTP GET:
 
 	DELETE http://yoururl.com/deletethis
 
-###Requesting through a proxy
+### Requesting through a proxy
 If you need to send the request through a proxy server you can use:
 
 	GET www.yourtest.com
@@ -60,26 +60,26 @@ If you need to send the request through a proxy server you can use:
 
 Where *127.0.0.1* is the proxy server address (IP or URL) followed by the port number. **Warning** : allways append a port number, even if it's *80*
 
-###Using client SSL certificates
+### Using client SSL certificates
 If you need client SSL certification you can use:
 
 	GET https://yoursecureserver.com
 	CLIENT_SSL_CERT: certif_file.pem
 	CLIENT_SSL_KEY: key_file.key
 
-###Using html charset
+### Using html charset
 If you need to make a request for a page with a specific encoding such as cyrillic you can use:
 
 	GET https://yoursecureserver.com
 	CHARSET: cp1251
 
-###Show results in the same results tab
+### Show results in the same results tab
 If you wish to have all the requests responses in the same file (tab), you can use the following param:
 
 	GET http://someserver.com
 	SAME_FILE: True
 
-###Set custom timeout
+### Set custom timeout
 For a custom request timeout value, use the following param (timeout in **seconds**):
 
 	GET http://someserver.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
